### PR TITLE
Fix typo in human_name method

### DIFF
--- a/lib/boxxspring/worker/base.rb
+++ b/lib/boxxspring/worker/base.rb
@@ -174,7 +174,7 @@ module Boxxspring
         self.class.name.  
           underscore.
           gsub( /[\/]/, ' ' ).
-          gsub( / worker\Z/, '' )
+          gsub( /_worker\Z/, '' )
       end
 
     end


### PR DESCRIPTION
human_name doesn't sub '_worker' correctly, resulting in double worker in the log.

```
Jul 24 16:12:05 vimeo_workers.acceptance boxxspring-vimeo-workers:  E, [2015-07-24T20:12:05.336181 #3] ERROR -- : The vimeo_subscription_metadata_worker worker failed to process the payload. undefined method `source_url' for #<Boxxspring::Task:0x007ff3fe680138>.
```
