### PR TITLE
Also rescue SignalException, when rescuing StandardError, to account …

### DIFF
--- a/lib/boxxspring/worker/task_base.rb
+++ b/lib/boxxspring/worker/task_base.rb
@@ -54,7 +54,7 @@ module Boxxspring
                     self.logger.info(  
                       message
                     )
-                  rescue StandardError => error
+                  rescue SignalException, StandardError => error
                     task = task_write_state( 
                       task, 
                       'failed', 


### PR DESCRIPTION
…for SIGTERMs, etc
