### PR TITLE
Log Forbidden error when worker doesn't have permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-boxxspring-ruby-client
+Boxxspring Worker SDK
 =====================
 
-The Boxxspring ruby client.

--- a/lib/boxxspring/worker/task_base.rb
+++ b/lib/boxxspring/worker/task_base.rb
@@ -70,8 +70,11 @@ module Boxxspring
                     raise error if error.is_a?( SignalException )
                   end
                 end
+              elsif task.is_a?(Array) &&
+                    task.first.is_a?(Boxxspring::ForbiddenError)
+                self.logger.error(task.first.message)
               else
-                self.logger.info(  
+                self.logger.error(
                   "The #{self.human_name} worker is unable to retrieve the " +
                   "task with the id #{task_id}."
                 )

--- a/lib/boxxspring/worker/task_base.rb
+++ b/lib/boxxspring/worker/task_base.rb
@@ -137,6 +137,13 @@ module Boxxspring
         self.delegate_payload( queue_name, payload )
       end
 
+      protected; def operation(endpoint)
+        Boxxspring::Operation.new(
+          endpoint,
+          Boxxspring::Worker.configuration.api_credentials.to_hash
+        )
+      end
+
     end
 
   end


### PR DESCRIPTION
When the env APPLICATION_ID is wrong or the app doesn't have permission, it says "Fails to retrieve the task", which can be confusing/not specific enough.
