### PR TITLE
Move operation method to worker base

### DIFF
--- a/lib/boxxspring/worker/base.rb
+++ b/lib/boxxspring/worker/base.rb
@@ -171,6 +171,13 @@ module Boxxspring
         end
       end
 
+      protected; def operation(endpoint)
+        Boxxspring::Operation.new(
+          endpoint,
+          Boxxspring::Worker.configuration.api_credentials.to_hash
+        )
+      end
+
       protected; def human_name
         self.class.name.  
           underscore.

--- a/lib/boxxspring/worker/task_base.rb
+++ b/lib/boxxspring/worker/task_base.rb
@@ -137,13 +137,6 @@ module Boxxspring
         self.delegate_payload( queue_name, payload )
       end
 
-      protected; def operation(endpoint)
-        Boxxspring::Operation.new(
-          endpoint,
-          Boxxspring::Worker.configuration.api_credentials.to_hash
-        )
-      end
-
     end
 
   end


### PR DESCRIPTION
So workers inheriting from Worker::Base can use this method. 
Worker::TaskBase inherit from Worker::Base so it will also be available to TaskBase.
