### PR TITLE
ARCPOR-775 Implement CloudWatch logging for worker start, stop, and stack trace log messages.

### DIFF
--- a/lib/boxxspring-worker.rb
+++ b/lib/boxxspring-worker.rb
@@ -4,6 +4,7 @@ require 'active_support/all'
 $LOAD_PATH.unshift( File.expand_path( '..', File.dirname( __FILE__ ) ) )
 require 'lib/boxxspring/abstract'
 require 'lib/boxxspring/journal'
+require 'lib/boxxspring/worker/logging'
 require 'lib/boxxspring/worker/configuration'
 require 'lib/boxxspring/worker/base'
 require 'lib/boxxspring/worker/task_base'

--- a/lib/boxxspring-worker.rb
+++ b/lib/boxxspring-worker.rb
@@ -4,6 +4,7 @@ require 'active_support/all'
 $LOAD_PATH.unshift( File.expand_path( '..', File.dirname( __FILE__ ) ) )
 require 'lib/boxxspring/abstract'
 require 'lib/boxxspring/journal'
+require 'lib/boxxspring/worker'
 require 'lib/boxxspring/worker/logging'
 require 'lib/boxxspring/worker/configuration'
 require 'lib/boxxspring/worker/base'

--- a/lib/boxxspring/abstract.rb
+++ b/lib/boxxspring/abstract.rb
@@ -13,6 +13,10 @@ module Boxxspring
       return @attributes
     end
 
+    def include?( name )
+      @attributes.include?( name )
+    end
+
     def method_missing( method, *arguments, &block )
       result = nil
       if arguments.length == 0 

--- a/lib/boxxspring/worker.rb
+++ b/lib/boxxspring/worker.rb
@@ -1,0 +1,23 @@
+module Boxxspring
+
+  module Worker
+
+    def self.configuration( &block )
+      Configuration.instance().instance_eval( &block ) unless block.nil?
+      Configuration.instance()
+    end
+
+    def self.env 
+      @environment ||= ENV[ 'WORKERS_ENV' ] || 'development'
+    end
+
+    def self.root
+      @root ||= begin 
+        specification = Gem::Specification.find_by_name( 'boxxspring-worker') 
+        Pathname.new( specification.gem_dir )
+      end
+    end
+
+  end
+
+end

--- a/lib/boxxspring/worker.rb
+++ b/lib/boxxspring/worker.rb
@@ -13,7 +13,7 @@ module Boxxspring
 
     def self.root
       @root ||= begin 
-        specification = Gem::Specification.find_by_name( 'boxxspring-worker') 
+        specification = Gem::Specification.find_by_name( 'boxxspring-workers' ) 
         Pathname.new( specification.gem_dir )
       end
     end

--- a/lib/boxxspring/worker/base.rb
+++ b/lib/boxxspring/worker/base.rb
@@ -10,6 +10,11 @@ module Boxxspring
     class Base
 
       #------------------------------------------------------------------------
+      # modules
+
+      include Logging
+
+      #------------------------------------------------------------------------
       # class attributes
 
       class_attribute :queue_name
@@ -84,13 +89,6 @@ module Boxxspring
             end
           end
         end
-      end
-
-      #------------------------------------------------------------------------
-      # operations, support
-
-      def logger 
-        Boxxspring::Worker.configuration.logger
       end
 
       #------------------------------------------------------------------------

--- a/lib/boxxspring/worker/base.rb
+++ b/lib/boxxspring/worker/base.rb
@@ -91,9 +91,9 @@ module Boxxspring
           remote_logger = ENV[ 'REMOTE_LOGGER' ] || ''
 
           if remote_logger.present?
+            worker_name = self.human_name.gsub( ' ','_' )
             if remote_logger == 'cloudwatch'
 
-              worker_name = human_name.gsub( ' ','_' )
               workers_env = ENV[ 'WORKERS_ENV' ]
               if workers_env == "development"
                 username = ENV[ 'USER' ] || ENV[ 'USERNAME' ]

--- a/lib/boxxspring/worker/base.rb
+++ b/lib/boxxspring/worker/base.rb
@@ -93,13 +93,14 @@ module Boxxspring
           if remote_logger.present?
             if remote_logger == 'cloudwatch'
 
+              worker_name = human_name.gsub( ' ','_' )
               workers_env = ENV[ 'WORKERS_ENV' ]
               if workers_env == "development"
                 username = ENV[ 'USER' ] || ENV[ 'USERNAME' ]
                 username = username.underscore.dasherize
                 cloud_group = "#{ workers_env }.#{ username }"
               else
-                cloud_group = "#{ ENV[ 'LOG_SYSTEM' ] }.#{ ENV[ 'WORKERS_ENV' ] }"
+                cloud_group = "#{ worker_name }.#{ ENV[ 'WORKERS_ENV' ] }"
               end
               cloud_stream = human_name
 
@@ -114,7 +115,6 @@ module Boxxspring
               remote_host   = remote_logger.split( ':' )[0]
               remote_port   = remote_logger.split( ':' )[1].to_i
 
-              worker_name = human_name.gsub( ' ','_' )
               worker_env = self.class.environment
               host_suffix = ( worker_env == 'production' ) ? '' : ".#{ worker_env }"
 

--- a/lib/boxxspring/worker/base.rb
+++ b/lib/boxxspring/worker/base.rb
@@ -100,9 +100,9 @@ module Boxxspring
                 username = username.underscore.dasherize
                 cloud_group = "#{ workers_env }.#{ username }"
               else
-                cloud_group = "#{ worker_name }.#{ ENV[ 'WORKERS_ENV' ] }"
+                cloud_group = "#{ ENV[ 'LOG_SYSTEM' ] }.#{ ENV[ 'WORKERS_ENV' ] }"
               end
-              cloud_stream = human_name
+              cloud_stream = worker_name
 
               logger = CloudWatchLogger.new( {
                 access_key_id: ENV[ 'AWS_ACCESS_KEY_ID' ],

--- a/lib/boxxspring/worker/base.rb
+++ b/lib/boxxspring/worker/base.rb
@@ -1,5 +1,3 @@
-require 'remote_syslog_logger'
-
 module Boxxspring
 
   module Worker

--- a/lib/boxxspring/worker/configuration.rb
+++ b/lib/boxxspring/worker/configuration.rb
@@ -4,24 +4,9 @@ module Boxxspring
 
   module Worker
 
-    def self.configuration( &block )
-      Configuration.instance().instance_eval( &block ) unless block.nil?
-      Configuration.instance()
-    end
-
-    def self.env 
-      self.configuration.env
-    end
-
     class Configuration < Abstract
 
       include Singleton
-
-      def initialize
-        super( { 
-          env: ENV[ 'WORKERS_ENV' ] || 'development'
-        } )  
-      end
 
       def self.reloadable?
         false

--- a/lib/boxxspring/worker/configuration.rb
+++ b/lib/boxxspring/worker/configuration.rb
@@ -16,7 +16,6 @@ module Boxxspring
     class Configuration < Abstract
 
       include Singleton
-      include Logging 
 
       def initialize
         super( { 

--- a/lib/boxxspring/worker/configuration.rb
+++ b/lib/boxxspring/worker/configuration.rb
@@ -16,11 +16,12 @@ module Boxxspring
     class Configuration < Abstract
 
       include Singleton
+      include Logging 
 
       def initialize
         super( { 
           env: ENV[ 'WORKERS_ENV' ] || 'development',
-          logger: Logger.new( STDOUT )
+          logger: default_logger
         } )  
       end
 

--- a/lib/boxxspring/worker/configuration.rb
+++ b/lib/boxxspring/worker/configuration.rb
@@ -19,8 +19,7 @@ module Boxxspring
 
       def initialize
         super( { 
-          env: ENV[ 'WORKERS_ENV' ] || 'development',
-          logger: nil 
+          env: ENV[ 'WORKERS_ENV' ] || 'development'
         } )  
       end
 

--- a/lib/boxxspring/worker/configuration.rb
+++ b/lib/boxxspring/worker/configuration.rb
@@ -21,7 +21,7 @@ module Boxxspring
       def initialize
         super( { 
           env: ENV[ 'WORKERS_ENV' ] || 'development',
-          logger: default_logger
+          logger: nil 
         } )  
       end
 

--- a/lib/boxxspring/worker/logging.rb
+++ b/lib/boxxspring/worker/logging.rb
@@ -4,6 +4,8 @@ module Boxxspring
 
     module Logging
 
+      PWD = Dir.pwd.freeze
+
       def logger
 
         @logger ||= begin
@@ -61,7 +63,7 @@ module Boxxspring
       protected; def log_group_name
         group_name = ENV[ 'LOG_GROUP' ]
         group_name ||= begin
-          File.open( Worker.root.join( 'GROUP' ), &:readline ) rescue nil       
+          File.open( File.join( PWD, 'GROUP' ), &:readline ) rescue nil       
         end
         group_name ||= begin 
           name = `git config --get remote.origin.url` rescue nil

--- a/lib/boxxspring/worker/logging.rb
+++ b/lib/boxxspring/worker/logging.rb
@@ -4,9 +4,12 @@ module Boxxspring
 
     module Logging
 
-      def default_logger
+      def logger
 
-        @default_logger || begin
+        @logger || begin
+
+          logger = Workers.configuration.logger 
+          return if logger.present?
 
           if self.log_local?
 
@@ -46,7 +49,7 @@ module Boxxspring
 
       end
 
-      def log_group_name
+      protected; def log_group_name
         group_name = ENV[ 'LOG_GROUP' ]
         group_name ||= begin 
           name = `git config --get remote.origin.url` rescue nil
@@ -55,7 +58,7 @@ module Boxxspring
         group_name
       end
 
-      def log_level 
+      protected; def log_level 
         level = Logger::WARN
         if ENV[ 'LOG_LEVEL' ].present? 
           level = ENV[ 'LOG_LEVEL' ].upcase
@@ -66,7 +69,7 @@ module Boxxspring
         level 
       end
 
-      def log_local?
+      protected; def log_local?
         log_local = ENV[ 'LOG_LOCAL' ] || 'false'
         ( log_local.to_s =~ /^true$/i ) == 0
       end      

--- a/lib/boxxspring/worker/logging.rb
+++ b/lib/boxxspring/worker/logging.rb
@@ -23,7 +23,8 @@ module Boxxspring
             else
 
               group_name = self.log_group_name 
-              raise 'A logging group is required' unless group_name.present?
+              raise 'A logging group is required. You may need to set LOG_GROUP.' \
+                unless group_name.present?
 
               worker_name = self.human_name.gsub( ' ','_' )
 
@@ -59,6 +60,9 @@ module Boxxspring
 
       protected; def log_group_name
         group_name = ENV[ 'LOG_GROUP' ]
+        group_name ||= begin
+          File.open( Worker.root.join( 'GROUP' ), &:readline ) rescue nil       
+        end
         group_name ||= begin 
           name = `git config --get remote.origin.url` rescue nil
           name.present? ? File.basename( name, '.*' ) : nil

--- a/lib/boxxspring/worker/logging.rb
+++ b/lib/boxxspring/worker/logging.rb
@@ -26,11 +26,13 @@ module Boxxspring
 
               worker_name = self.human_name.gsub( ' ','_' )
 
-              if workers_env == "development"
+              if workers_env == 'development'
                 username = ENV[ 'USER' ] || ENV[ 'USERNAME' ]
                 username = username.underscore.dasherize
 
                 group_name = "#{ username }.#{ group_name }"
+              elsif workers_env != 'production'
+                group_name = "#{ workers_env }.#{ group_name }"
               end
 
               logger = CloudWatchLogger.new( 

--- a/lib/boxxspring/worker/logging.rb
+++ b/lib/boxxspring/worker/logging.rb
@@ -1,0 +1,78 @@
+module Boxxspring 
+
+  module Worker
+
+    module Logging
+
+      def default_logger
+
+        @default_logger || begin
+
+          if self.log_local?
+
+            logger = Logger.new( STDOUT )
+
+          else
+
+            workers_env = ENV[ 'WORKERS_ENV' ]
+            group_name = self.group_name 
+            raise 'A logging group is required' unless group_name.present?
+
+            worker_name = self.human_name.gsub( ' ','_' )
+
+            if workers_env == "development"
+              username = ENV[ 'USER' ] || ENV[ 'USERNAME' ]
+              username = username.underscore.dasherize
+
+              group_name = "#{ username }.#{ group_name }"
+            end
+
+            logger = CloudWatchLogger.new( 
+              {
+                access_key_id: ENV[ 'AWS_ACCESS_KEY_ID' ],
+                secret_access_key: ENV[ 'AWS_SECRET_ACCESS_KEY' ] 
+              },
+              group_name,
+              worker_name 
+            )
+
+          end
+
+          logger.level = self.log_level 
+
+          logger
+            
+        end
+
+      end
+
+      def log_group_name
+        group_name = ENV[ 'LOG_GROUP' ]
+        group_name ||= begin 
+          name = `git config --get remote.origin.url` rescue nil
+          name.present? ? File.basename( name, '.*' ) : nil
+        end
+        group_name
+      end
+
+      def log_level 
+        level = Logger::WARN
+        if ENV[ 'LOG_LEVEL' ].present? 
+          level = ENV[ 'LOG_LEVEL' ].upcase
+          raise "An unkown log level was specificed by LOG_LEVEL." \
+            unless [ "INFO", "WARN", "ERROR", "DEBUG", "FATAL" ].include?( level )
+          level = "Logger::#{ level }".constantize
+        end 
+        level 
+      end
+
+      def log_local?
+        log_local = ENV[ 'LOG_LOCAL' ] || 'false'
+        ( log_local.to_s =~ /^true$/i ) == 0
+      end      
+
+    end
+
+  end
+
+end

--- a/lib/boxxspring/worker/logging.rb
+++ b/lib/boxxspring/worker/logging.rb
@@ -8,19 +8,20 @@ module Boxxspring
 
         @logger ||= begin
 
+          workers_env = ENV[ 'WORKERS_ENV' ]
+
           if Worker.configuration.include?( 'logger' ) 
 
            logger = Worker.configuration.logger 
 
           else 
 
-            if self.log_local?
+            if self.log_local? || workers_env == 'test'
 
               logger = Logger.new( STDOUT )
 
             else
 
-              workers_env = ENV[ 'WORKERS_ENV' ]
               group_name = self.log_group_name 
               raise 'A logging group is required' unless group_name.present?
 

--- a/lib/boxxspring/worker/logging.rb
+++ b/lib/boxxspring/worker/logging.rb
@@ -1,4 +1,4 @@
-module Boxxspring 
+module Boxxspring
 
   module Worker
 
@@ -12,11 +12,11 @@ module Boxxspring
 
           workers_env = ENV[ 'WORKERS_ENV' ]
 
-          if Worker.configuration.include?( 'logger' ) 
+          if Worker.configuration.include?( 'logger' )
 
-           logger = Worker.configuration.logger 
+           logger = Worker.configuration.logger
 
-          else 
+          else
 
             if self.log_local? || workers_env == 'test'
 
@@ -24,7 +24,7 @@ module Boxxspring
 
             else
 
-              group_name = self.log_group_name 
+              group_name = self.log_group_name
               raise 'A logging group is required. You may need to set LOG_GROUP.' \
                 unless group_name.present?
 
@@ -39,13 +39,13 @@ module Boxxspring
                 group_name = "#{ workers_env }.#{ group_name }"
               end
 
-              logger = CloudWatchLogger.new( 
+              logger = CloudWatchLogger.new(
                 {
                   access_key_id: ENV[ 'AWS_ACCESS_KEY_ID' ],
-                  secret_access_key: ENV[ 'AWS_SECRET_ACCESS_KEY' ] 
+                  secret_access_key: ENV[ 'AWS_SECRET_ACCESS_KEY' ]
                 },
                 group_name,
-                worker_name 
+                worker_name
               )
 
             end
@@ -53,9 +53,9 @@ module Boxxspring
 
           end
 
-          logger.level = self.log_level 
+          logger.level = self.log_level
           logger
-            
+
         end
 
       end
@@ -63,30 +63,30 @@ module Boxxspring
       protected; def log_group_name
         group_name = ENV[ 'LOG_GROUP' ]
         group_name ||= begin
-          File.open( File.join( PWD, 'GROUP' ), &:readline ) rescue nil       
+          File.open( File.join( PWD, 'GROUP' ), &:readline ) rescue nil
         end
-        group_name ||= begin 
+        group_name ||= begin
           name = `git config --get remote.origin.url` rescue nil
           name.present? ? File.basename( name, '.*' ) : nil
         end
-        group_name
+        group_name.strip
       end
 
-      protected; def log_level 
+      protected; def log_level
         level = Logger::WARN
-        if ENV[ 'LOG_LEVEL' ].present? 
+        if ENV[ 'LOG_LEVEL' ].present?
           level = ENV[ 'LOG_LEVEL' ].upcase
           raise "An unkown log level was specificed by LOG_LEVEL." \
             unless [ "INFO", "WARN", "ERROR", "DEBUG", "FATAL" ].include?( level )
           level = "Logger::#{ level }".constantize
-        end 
-        level 
+        end
+        level
       end
 
       protected; def log_local?
         log_local = ENV[ 'LOG_LOCAL' ] || 'false'
         ( log_local.to_s =~ /^true$/i ) == 0
-      end      
+      end
 
     end
 


### PR DESCRIPTION
This implementation of CloudWatch logging preserves the existing Papertrail logging unless the remote logging environment variable is set to 'cloudwatch'.